### PR TITLE
Drop th-lift-instances dependency

### DIFF
--- a/file-embed-lzma.cabal
+++ b/file-embed-lzma.cabal
@@ -57,7 +57,6 @@ library
   -- non bundled dependencies
   build-depends:
       lzma               ^>=0.0.0.3
-    , th-lift-instances  ^>=0.1.11
 
   other-extensions:
     OverloadedStrings

--- a/src/FileEmbedLzma.hs
+++ b/src/FileEmbedLzma.hs
@@ -50,8 +50,6 @@ import qualified Data.Text               as T
 import qualified Data.Text.Lazy          as LT
 import qualified Data.Text.Lazy.Encoding as LTE
 
-import Instances.TH.Lift ()
-
 listRecursiveDirectoryFiles :: FilePath -> IO [(FilePath, LBS.ByteString)]
 listRecursiveDirectoryFiles = listDirectoryFilesF listRecursiveDirectoryFiles
 


### PR DESCRIPTION
According to my local tests, it doesn't seem like removing this dependency breaks any builds, including GHC 7.10.

[th-lift](https://hackage.haskell.org/package/th-lift) mentions that only GHC 8.0 should have "largely" made th-lift superfluous, so I am unsure which parts are missing in 7.10.

If this dependency can't be removed yet, it would be nice to expand the tests to have them cover this.